### PR TITLE
Some patches that make hydro-devel work with catkin_make_isolated

### DIFF
--- a/rtt_roscomm/CMakeLists.txt
+++ b/rtt_roscomm/CMakeLists.txt
@@ -48,30 +48,20 @@ orocos_service(rtt_rosservice
   src/rtt_rosservice_service.cpp)
 target_link_libraries(rtt_rosservice ${catkin_LIBRARIES})
 
-
-# Generate install targets for headers
-orocos_install_headers(
-  include/rtt_rostopic/rtt_rostopic.h
-  include/rtt_rostopic/ros_msg_transporter.hpp
-  include/rtt_rostopic/ros_publish_activity.hpp
-  include/rtt_rosservice/ros_service_proxy.h
-  )
-
 # Generate install targets and pkg-config files
 orocos_generate_package()
 
 install(PROGRAMS 
-  scripts/create_boost_headers.py
-  scripts/create_rtt_msgs
+  scripts/create_rtt_pkg
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
-install(DIRECTORY include/${PROJECT_NAME}/
-   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+install(DIRECTORY include/
+   DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}
    FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp"
 )
 
 # Install cmake macros
-install(FILES cmake/GenerateRTTROSCommPackage.cmake cmake/create_boost_header.py
+install(PROGRAMS cmake/create_boost_header.py
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/cmake)
 
 # Install template files to both install and develspace

--- a/rtt_roscomm/cmake/GenerateRTTROSCommPackage.cmake.em
+++ b/rtt_roscomm/cmake/GenerateRTTROSCommPackage.cmake.em
@@ -148,6 +148,11 @@ function(ros_generate_rtt_typekit package)
   set_directory_properties(PROPERTIES 
     ADDITIONAL_MAKE_CLEAN_FILES "${ROSMSG_TYPEKIT_PLUGINS};${ROSMSG_TRANSPORT_PLUGIN};${_template_types_dst_dir}/ros_${package}_typekit.cpp;${_template_types_dst_dir}/ros_${package}_transport.cpp;${CATKIN_DEVEL_PREFIX}/include/${package}/boost")
 
+  # Install generated header files (dependent packages might need them)
+  foreach (HEADER ${ROSMSGS_GENERATED_BOOST_HEADERS})
+    install(FILES ${HEADER} DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}/${package}/boost/)
+  endforeach()
+
 endfunction(ros_generate_rtt_typekit)
 
 

--- a/rtt_roscomm/cmake/GenerateRTTROSCommPackage.cmake.em
+++ b/rtt_roscomm/cmake/GenerateRTTROSCommPackage.cmake.em
@@ -149,9 +149,7 @@ function(ros_generate_rtt_typekit package)
     ADDITIONAL_MAKE_CLEAN_FILES "${ROSMSG_TYPEKIT_PLUGINS};${ROSMSG_TRANSPORT_PLUGIN};${_template_types_dst_dir}/ros_${package}_typekit.cpp;${_template_types_dst_dir}/ros_${package}_transport.cpp;${CATKIN_DEVEL_PREFIX}/include/${package}/boost")
 
   # Install generated header files (dependent packages might need them)
-  foreach (HEADER ${ROSMSGS_GENERATED_BOOST_HEADERS})
-    install(FILES ${HEADER} DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}/${package}/boost/)
-  endforeach()
+  install(FILES ${ROSMSGS_GENERATED_BOOST_HEADERS} DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}/${package}/boost/)
 
 endfunction(ros_generate_rtt_typekit)
 

--- a/rtt_roscomm/cmake/GenerateRTTROSCommPackage.cmake.em
+++ b/rtt_roscomm/cmake/GenerateRTTROSCommPackage.cmake.em
@@ -40,7 +40,7 @@ function(ros_generate_rtt_typekit package)
   @[if DEVELSPACE]@
     set(CREATE_BOOST_HEADER_EXE_PATH @(CMAKE_CURRENT_SOURCE_DIR)/cmake/create_boost_header.py)
   @[else]@
-    set(CREATE_BOOST_HEADER_EXE_PATH "create_boost_header.py")
+    set(CREATE_BOOST_HEADER_EXE_PATH @(CMAKE_INSTALL_PREFIX)/@(CATKIN_PACKAGE_SHARE_DESTINATION)/cmake/create_boost_header.py)
   @[end if]@
 
   # Store the ros package name


### PR DESCRIPTION
When each package is built and installed separately (e.g. with catkin_make_isolated), header files that are also needed by dependent projects need to be installed as the devel or source space is not accessible. I guess this is also what the ROS buildfarm would do.

5d69810 is more or less a bugfix. I guess there have been some file renamings recently. 0037592 adds an install rule for generated boost headers.

With these patches, rtt_ros_integration and rtt_common_msgs compile successfully on my machine with `catkin_make_isolated --install`.
