### PR TITLE
rtt_roscomm: Add rosbuild support in rtt_ros service

### DIFF
--- a/rtt_roscomm/CMakeLists.txt
+++ b/rtt_roscomm/CMakeLists.txt
@@ -65,8 +65,9 @@ install(PROGRAMS cmake/create_boost_header.py
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/cmake)
 
 # Install template files to both install and develspace
-install(DIRECTORY rtt_roscomm_pkg_template DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/cmake)
-file(COPY rtt_roscomm_pkg_template DESTINATION "${CATKIN_DEVEL_PREFIX}/share/${PROJECT_NAME}/cmake")
+install(DIRECTORY rtt_roscomm_pkg_template DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+# Why develspace? rospack finds the package in its source dir in devel-spaces.
+#file(COPY rtt_roscomm_pkg_template DESTINATION "${CATKIN_DEVEL_PREFIX}/share/${PROJECT_NAME}/cmake")
 
 # Install tests
 install(FILES 

--- a/test/rtt_ros_tests/CMakeLists.txt
+++ b/test/rtt_ros_tests/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(rtt_ros_tests)
+
+find_package(catkin REQUIRED)
+
+if(CATKIN_ENABLE_TESTING)
+
+endif()
+
+catkin_package()
+
+

--- a/test/rtt_ros_tests/package.xml
+++ b/test/rtt_ros_tests/package.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0"?>
+<package>
+  <name>rtt_ros_tests</name>
+  <version>0.0.0</version>
+  <description>The rtt_ros_tests package</description>
+
+  <!-- One maintainer tag required, multiple allowed, one person per tag --> 
+  <!-- Example:  -->
+  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
+  <maintainer email="jbo@jhu.edu">Jonathan Bohren</maintainer>
+
+
+  <!-- One license tag required, multiple allowed, one license per tag -->
+  <!-- Commonly used license strings: -->
+  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
+  <license>BSD</license>
+
+
+  <!-- Url tags are optional, but mutiple are allowed, one per tag -->
+  <!-- Optional attribute type can be: website, bugtracker, or repository -->
+  <!-- Example: -->
+  <!-- <url type="website">http://ros.org/wiki/rtt_ros_tests</url> -->
+
+
+  <!-- Author tags are optional, mutiple are allowed, one per tag -->
+  <!-- Authors do not have to be maintianers, but could be -->
+  <!-- Example: -->
+  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
+
+
+  <!-- The *_depend tags are used to specify dependencies -->
+  <!-- Dependencies can be catkin packages or system dependencies -->
+  <!-- Examples: -->
+  <!-- Use build_depend for packages you need at compile time: -->
+  <!--   <build_depend>message_generation</build_depend> -->
+  <!-- Use buildtool_depend for build tool packages: -->
+  <!--   <buildtool_depend>catkin</buildtool_depend> -->
+  <!-- Use run_depend for packages you need at runtime: -->
+  <!--   <run_depend>message_runtime</run_depend> -->
+  <!-- Use test_depend for packages you need only for testing: -->
+  <!--   <test_depend>gtest</test_depend> -->
+  <buildtool_depend>catkin</buildtool_depend>
+
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <!-- You can specify that this package is a metapackage here: -->
+    <!-- <metapackage/> -->
+
+    <!-- Other tools can request additional information be placed here -->
+
+  </export>
+</package>


### PR DESCRIPTION
For being able to use the new rtt_ros service with rosbuild packages, the following updates have been necessary in the rtt_ros import operation:
- Also accept `manifest.xml` as file name for package manifests (using the same `<export><rtt_ros><plugin_depend>` xpath query). 
- Add paths of dependent rosbuild packages (packages that only have a manifest.xml file but no package.xml file) to the search paths list.
- Removed the final import of the package itself as it is already in the `deps_to_import` list.

I tested this version with my rosbuild packages that `plugin_depend` from other rosbuild packages and from installed typekit/library packages from this repository.
