### PR TITLE
rtt_roscomm: Boost header generation broken with genmsg 0.4.22

### DIFF
--- a/rtt_roscomm/cmake/GenerateRTTROSCommPackage.cmake.em
+++ b/rtt_roscomm/cmake/GenerateRTTROSCommPackage.cmake.em
@@ -81,6 +81,11 @@ macro(ros_generate_rtt_typekit package)
     foreach( FILE ${MSGS} )
       # Get just the message name
       string(REGEX REPLACE ".+/\(.+\).msg" "\\1" ROSMSGNAME ${FILE})
+
+      # Resolve relative paths
+      if(NOT IS_ABSOLUTE ${FILE})
+        set(FILE "${${package}_DIR}/../${FILE}")
+      endif()
       
       # Define the typenames for this message
       set(ROSMSGTYPE         "${package}::${ROSMSGNAME}")


### PR DESCRIPTION
ros/genmsg#32 has broken typekit generation as `${${package}_MESSAGE_FILES}` variable contains relative paths now. The current Ubuntu repositories serve genmsg 0.4.22 including that patch since today.

We have to check if this can be considered a bug in genmsg or if there is a simple way to get the absolute path in a generic way.

Possible solution (not tested yet):

``` cmake
if(NOT IS_ABSOLUTE "${FILE}")
  set(FILE "${${package}_DIR}/${FILE}")
endif()
```
