### PR TITLE
rtt_roscomm: Paths of the rtt_roscomm_pkg_template folder differs in devel-space and install-space

### DIFF
--- a/rtt_roscomm/CMakeLists.txt
+++ b/rtt_roscomm/CMakeLists.txt
@@ -68,7 +68,7 @@ install(PROGRAMS cmake/create_boost_header.py
 
 # Install template files to both install and develspace
 install(DIRECTORY rtt_roscomm_pkg_template DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
-file(COPY rtt_roscomm_pkg_template DESTINATION "${CATKIN_DEVEL_PREFIX}/share/${PROJECT_NAME}/cmake")
+file(COPY rtt_roscomm_pkg_template DESTINATION "${CATKIN_DEVEL_PREFIX}/share/${PROJECT_NAME}")
 
 # Install tests
 install(FILES 

--- a/rtt_roscomm/cmake/GenerateRTTROSCommPackage.cmake.em
+++ b/rtt_roscomm/cmake/GenerateRTTROSCommPackage.cmake.em
@@ -131,10 +131,10 @@ macro(ros_generate_rtt_typekit package)
       #set_source_files_properties(${ROSMSGS_GENERATED_BOOST_HEADERS} PROPERTIES GENERATED TRUE)
       
       # TypeInfo object
-      set(_template_types_src_dir "${rtt_roscomm_DIR}/rtt_roscomm_pkg_template/src/orocos/types")
+      set(_template_types_src_dir "${rtt_roscomm_DIR}/../rtt_roscomm_pkg_template/src/orocos/types")
       set(_template_types_dst_dir "${rtt_roscomm_GENERATED_SOURCES_OUTPUT_DIRECTORY}/orocos/types")
 
-      set(_template_typekit_src_dir "${rtt_roscomm_DIR}/rtt_roscomm_pkg_template/include/PKG_NAME/typekit")
+      set(_template_typekit_src_dir "${rtt_roscomm_DIR}/../rtt_roscomm_pkg_template/include/PKG_NAME/typekit")
       set(_template_typekit_dst_dir "${rtt_roscomm_GENERATED_HEADERS_OUTPUT_DIRECTORY}/${package}/typekit")
 
       configure_file( 
@@ -264,7 +264,7 @@ macro(ros_generate_rtt_service_proxies package)
     endforeach()
     
     # Service proxy factories
-    set(_template_proxies_src_dir "${rtt_roscomm_DIR}/rtt_roscomm_pkg_template/src")
+    set(_template_proxies_src_dir "${rtt_roscomm_DIR}/../rtt_roscomm_pkg_template/src")
     set(_template_proxies_dst_dir "${CMAKE_CURRENT_BINARY_DIR}/src")
 
     configure_file( 


### PR DESCRIPTION
Install-space deployments of package rtt_roscomm are currently broken as `${rtt_roscomm_DIR}` resolves to share/rtt_roscomm/cmake in `GenerateRTTROSCommPackage.cmake`. The template files should not be installed to the subfolder cmake in order to keep the path consistent between package source, devel-space and install-space.
