### PR TITLE
rtt_roscomm: fix output directory for generated typekit headers

### DIFF
--- a/rtt_roscomm/cmake/GenerateRTTROSCommPackage.cmake.em
+++ b/rtt_roscomm/cmake/GenerateRTTROSCommPackage.cmake.em
@@ -155,7 +155,7 @@ macro(ros_generate_rtt_typekit package)
       set(_template_types_dst_dir "${rtt_roscomm_GENERATED_SOURCES_OUTPUT_DIRECTORY}/orocos/types")
 
       set(_template_typekit_src_dir "${rtt_roscomm_DIR}/../rtt_roscomm_pkg_template/include/PKG_NAME/typekit")
-      set(_template_typekit_dst_dir "${rtt_roscomm_GENERATED_HEADERS_OUTPUT_DIRECTORY}/${package}/typekit")
+      set(_template_typekit_dst_dir "${rtt_roscomm_GENERATED_HEADERS_OUTPUT_DIRECTORY}/orocos/${package}/typekit")
 
       configure_file( 
         ${_template_types_src_dir}/ros_msg_typekit_plugin.cpp.in 


### PR DESCRIPTION
8dbf5048d96abd4d8036c55c6b9eff78208b983c broke installation of typekit headers, as they have been generated without the `orocos/` component in the path and therefore have not been covered by the install rule in [GenerateRTTROSCommPackage.cmake.em#L230](https://github.com/jhu-lcsr-forks/rtt_ros_integration/blob/41be612568f23641fd950ba014800da0eb2a6661/rtt_roscomm/cmake/GenerateRTTROSCommPackage.cmake.em#L230).
