### PR TITLE
Removed all dependencies to rtt and ocl in catkin_package()

### DIFF
--- a/rtt_actionlib/CMakeLists.txt
+++ b/rtt_actionlib/CMakeLists.txt
@@ -11,7 +11,7 @@ include(${OROCOS-RTT_USE_FILE_PATH}/UseOROCOS-RTT.cmake)
 
 catkin_package(
   INCLUDE_DIRS include 
-  DEPENDS rtt ocl
+#  DEPENDS rtt ocl
   CATKIN_DEPENDS roscpp rtt_roscomm actionlib)
 
 include_directories(

--- a/rtt_ros/CMakeLists.txt
+++ b/rtt_ros/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(catkin REQUIRED COMPONENTS roscpp rospack)
 
 catkin_package(
   INCLUDE_DIRS include
-  DEPENDS rtt ocl
+#  DEPENDS rtt ocl
   CATKIN_DEPENDS roscpp)
 
 set(CMAKE_BUILD_TYPE RelWithDebInfo)

--- a/rtt_roscomm/CMakeLists.txt
+++ b/rtt_roscomm/CMakeLists.txt
@@ -10,7 +10,7 @@ include(${OROCOS-RTT_USE_FILE_PATH}/UseOROCOS-RTT.cmake)
 
 catkin_package(
   INCLUDE_DIRS include 
-  DEPENDS rtt ocl
+#  DEPENDS rtt ocl
   CATKIN_DEPENDS roscpp  rtt_rospack 
   CFG_EXTRAS GenerateRTTROSCommPackage.cmake)
 

--- a/rtt_roscomm/rtt_roscomm_pkg_template/CMakeLists.txt
+++ b/rtt_roscomm/rtt_roscomm_pkg_template/CMakeLists.txt
@@ -10,7 +10,7 @@ ros_generate_rtt_typekit(@pkgname@)
 ros_generate_rtt_service_proxies(@pkgname@)
 
 catkin_package(
-  DEPENDS ocl rtt
+#  DEPENDS ocl rtt
   CATKIN_DEPENDS 
   rtt_roscomm 
   @pkgname@

--- a/rtt_roscomm/scripts/create_rtt_pkg
+++ b/rtt_roscomm/scripts/create_rtt_pkg
@@ -65,9 +65,9 @@ for dep in $(rospack depends $pkgname | grep "_msgs$"); do
     echo "WARNING: The package 'rtt_$dep' does not exist yet, however, 'rtt_$pkgname' will depend on it !"
     echo "         Use '$(basename $0) $dep' to create this missing package..."
   fi
-  deplist="$deplist  <build_depend>rtt_$dep</build_depend>\n  <run_depend>rtt_$dep</run_depend>"
-  rtt_deplist="$rtt_deplist      <plugin_depend>rtt_$dep</plugin_depend>"
-  catkin_deplist="$catkin_deplist  rtt_$dep"
+  deplist="$deplist  <build_depend>rtt_$dep</build_depend>\n  <run_depend>rtt_$dep</run_depend>\n"
+  rtt_deplist="$rtt_deplist      <plugin_depend>rtt_$dep</plugin_depend>\n"
+  catkin_deplist="$catkin_deplist  rtt_$dep\n"
 done
 
 mkdir $force rtt_$pkgname || { echo "Package already exists, use -f to force creation." ; exit 1; }

--- a/rtt_rosnode/CMakeLists.txt
+++ b/rtt_rosnode/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package(OROCOS-RTT REQUIRED rtt-marshalling)
 include(${OROCOS-RTT_USE_FILE_PATH}/UseOROCOS-RTT.cmake)
 
 catkin_package(
-  DEPENDS rtt ocl
+#  DEPENDS rtt ocl
   CATKIN_DEPENDS roscpp )
 
 include_directories(${catkin_INCLUDE_DIRS})

--- a/rtt_rospack/CMakeLists.txt
+++ b/rtt_rospack/CMakeLists.txt
@@ -16,6 +16,6 @@ target_link_libraries(rtt_rospack ${roslib_LIBRARIES})
 orocos_generate_package()
 
 catkin_package(
-  DEPENDS  rtt
+#  DEPENDS  rtt
   CATKIN_DEPENDS roslib 
 )

--- a/rtt_rosparam/CMakeLists.txt
+++ b/rtt_rosparam/CMakeLists.txt
@@ -12,7 +12,7 @@ include(${OROCOS-RTT_USE_FILE_PATH}/UseOROCOS-RTT.cmake)
 
 catkin_package(
   INCLUDE_DIRS include
-  DEPENDS rtt ocl
+#  DEPENDS rtt ocl
   CATKIN_DEPENDS roscpp)
 
 include_directories(


### PR DESCRIPTION
- Packages that want to use RTT always have to call find_package(OROCOS-RTT ...).
- Catkin does not respect the LIBRARY_DIRS for rtt and ocl correctly when using DEPENDS, so this will not work anyway. See https://github.com/ros/catkin/issues/535.

The only option to make that work is to create a new package that calls `find_package(OROCOS-RTT ...` and optionally also includes the `UseOrocosRTT.cmake` script in one of its `CFG_EXTRAS` files and appends the RTT libraries to its packagename_LIBRARIES variable. This could also be integrated in rtt_ros directly.

This would allow catkin users to write very simple cmake files like this:

```
find_package(catkin REQUIRED COMPONENTS rtt_ros)
include_directories(${catkin_INCLUDE_DIRECTORIES})
orocos_component(foo ...)
target_link_libraries(foo ${catkin_LIBRARIES})
```
