### PR TITLE
Add automatic use-orocos include to rtt_ros cfg-extras

### DIFF
--- a/rtt_actionlib/CMakeLists.txt
+++ b/rtt_actionlib/CMakeLists.txt
@@ -3,11 +3,6 @@ project(rtt_actionlib)
 
 find_package(catkin REQUIRED COMPONENTS
   roscpp rtt_ros actionlib rtt_roscomm)
-find_package(OROCOS-RTT REQUIRED rtt-marshalling)
-
-# Defines the orocos_* cmake macros. See that file for additional
-# documentation.
-include(${OROCOS-RTT_USE_FILE_PATH}/UseOROCOS-RTT.cmake)
 
 catkin_package(
   INCLUDE_DIRS include 

--- a/rtt_ros/CMakeLists.txt
+++ b/rtt_ros/CMakeLists.txt
@@ -4,7 +4,7 @@ project(rtt_ros)
 find_package(catkin REQUIRED COMPONENTS roscpp rospack)
 
 find_package(OROCOS-RTT REQUIRED 
-  COMPONENTS rtt-marshalling rtt-scripting rtt-transport-corba)
+  COMPONENTS rtt-marshalling rtt-scripting)
 include(${OROCOS-RTT_USE_FILE_PATH}/UseOROCOS-RTT.cmake)
 
 catkin_package(

--- a/rtt_ros/CMakeLists.txt
+++ b/rtt_ros/CMakeLists.txt
@@ -6,7 +6,8 @@ find_package(catkin REQUIRED COMPONENTS roscpp rospack)
 catkin_package(
   INCLUDE_DIRS include
   DEPENDS rtt ocl
-  CATKIN_DEPENDS roscpp)
+  CATKIN_DEPENDS roscpp
+  CFG_EXTRAS rtt_ros-extras.cmake)
 
 set(CMAKE_BUILD_TYPE RelWithDebInfo)
 

--- a/rtt_ros/CMakeLists.txt
+++ b/rtt_ros/CMakeLists.txt
@@ -3,6 +3,10 @@ project(rtt_ros)
 
 find_package(catkin REQUIRED COMPONENTS roscpp rospack)
 
+find_package(OROCOS-RTT REQUIRED 
+  COMPONENTS rtt-marshalling rtt-scripting rtt-transport-corba)
+include(${OROCOS-RTT_USE_FILE_PATH}/UseOROCOS-RTT.cmake)
+
 catkin_package(
   INCLUDE_DIRS include
   DEPENDS rtt ocl
@@ -11,15 +15,10 @@ catkin_package(
 
 set(CMAKE_BUILD_TYPE RelWithDebInfo)
 
-find_package(OROCOS-RTT REQUIRED rtt-marshalling)
 find_package(LibXml2 REQUIRED)
 
 # This adds orocos environment variables to the catkin setup.sh
 catkin_add_env_hooks(10.orocos SHELLS sh DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/env-hooks)
-
-# Defines the orocos_* cmake macros. See that file for additional
-# documentation.
-include(${OROCOS-RTT_USE_FILE_PATH}/UseOROCOS-RTT.cmake)
 
 include_directories(include ${catkin_INCLUDE_DIRS} ${LIBXML2_INCLUDE_DIR})
 

--- a/rtt_ros/cmake/rtt_ros-extras.cmake.in
+++ b/rtt_ros/cmake/rtt_ros-extras.cmake.in
@@ -1,0 +1,4 @@
+set(ORO_USE_CATKIN True)
+find_package(OROCOS-RTT REQUIRED 
+  COMPONENTS rtt-marshalling rtt-scripting rtt-transport-corba)
+include(${OROCOS-RTT_USE_FILE_PATH}/UseOROCOS-RTT.cmake)

--- a/rtt_ros/cmake/rtt_ros-extras.cmake.in
+++ b/rtt_ros/cmake/rtt_ros-extras.cmake.in
@@ -1,4 +1,3 @@
-set(ORO_USE_CATKIN True)
 find_package(OROCOS-RTT REQUIRED 
-  COMPONENTS rtt-marshalling rtt-scripting rtt-transport-corba)
+  COMPONENTS rtt-marshalling rtt-scripting)
 include(${OROCOS-RTT_USE_FILE_PATH}/UseOROCOS-RTT.cmake)

--- a/rtt_roscomm/CMakeLists.txt
+++ b/rtt_roscomm/CMakeLists.txt
@@ -1,12 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rtt_roscomm)
 
-find_package(catkin REQUIRED COMPONENTS roscpp rtt_rospack )
-find_package(OROCOS-RTT REQUIRED rtt-marshalling)
-
-# Defines the orocos_* cmake macros. See that file for additional
-# documentation.
-include(${OROCOS-RTT_USE_FILE_PATH}/UseOROCOS-RTT.cmake)
+find_package(catkin REQUIRED COMPONENTS roscpp rtt_rospack rtt_ros)
 
 catkin_package(
   INCLUDE_DIRS include 

--- a/rtt_roscomm/scripts/create_rtt_pkg
+++ b/rtt_roscomm/scripts/create_rtt_pkg
@@ -65,9 +65,9 @@ for dep in $(rospack depends $pkgname | grep "_msgs$"); do
     echo "WARNING: The package 'rtt_$dep' does not exist yet, however, 'rtt_$pkgname' will depend on it !"
     echo "         Use '$(basename $0) $dep' to create this missing package..."
   fi
-  deplist="$deplist  <build_depend>rtt_$dep</build_depend>\n  <run_depend>rtt_$dep</run_depend>"
-  rtt_deplist="$rtt_deplist      <plugin_depend>rtt_$dep</plugin_depend>"
-  catkin_deplist="$catkin_deplist  rtt_$dep"
+  deplist="$deplist  <build_depend>rtt_$dep</build_depend>\n  <run_depend>rtt_$dep</run_depend>\n"
+  rtt_deplist="$rtt_deplist      <plugin_depend>rtt_$dep</plugin_depend>\n"
+  catkin_deplist="$catkin_deplist  rtt_$dep\n"
 done
 
 mkdir $force rtt_$pkgname || { echo "Package already exists, use -f to force creation." ; exit 1; }

--- a/rtt_rosnode/CMakeLists.txt
+++ b/rtt_rosnode/CMakeLists.txt
@@ -1,12 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rtt_rosnode)
 
-find_package(catkin REQUIRED COMPONENTS roscpp )
-find_package(OROCOS-RTT REQUIRED rtt-marshalling)
-
-# Defines the orocos_* cmake macros. See that file for additional
-# documentation.
-include(${OROCOS-RTT_USE_FILE_PATH}/UseOROCOS-RTT.cmake)
+find_package(catkin REQUIRED COMPONENTS roscpp rtt_ros)
 
 catkin_package(
   DEPENDS rtt ocl

--- a/rtt_rospack/CMakeLists.txt
+++ b/rtt_rospack/CMakeLists.txt
@@ -1,13 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rtt_rospack)
 
-find_package(catkin REQUIRED COMPONENTS roslib)
-
-find_package(OROCOS-RTT REQUIRED)
-
-# Defines the orocos_* cmake macros. See that file for additional
-# documentation.
-include(${OROCOS-RTT_USE_FILE_PATH}/UseOROCOS-RTT.cmake)
+find_package(catkin REQUIRED COMPONENTS roslib rtt_ros)
 
 #build ROS pack as a separate service
 orocos_plugin(rtt_rospack src/rtt_rospack_service.cpp)

--- a/rtt_rosparam/CMakeLists.txt
+++ b/rtt_rosparam/CMakeLists.txt
@@ -3,12 +3,7 @@ project(rtt_rosparam)
 
 set(CMAKE_BUILD_TYPE Debug)
 
-find_package(catkin REQUIRED COMPONENTS roscpp )
-find_package(OROCOS-RTT REQUIRED rtt-marshalling)
-
-# Defines the orocos_* cmake macros. See that file for additional
-# documentation.
-include(${OROCOS-RTT_USE_FILE_PATH}/UseOROCOS-RTT.cmake)
+find_package(catkin REQUIRED COMPONENTS roscpp rtt_ros)
 
 catkin_package(
   INCLUDE_DIRS include

--- a/tests/rtt_ros_tests/CMakeLists.txt
+++ b/tests/rtt_ros_tests/CMakeLists.txt
@@ -1,9 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rtt_ros_tests)
 
-find_package(OROCOS-RTT REQUIRED COMPONENTS rtt-scripting)
-include(${OROCOS-RTT_USE_FILE_PATH}/UseOROCOS-RTT.cmake)
-
 find_package(catkin REQUIRED
   COMPONENTS rtt_ros)
 

--- a/tests/rtt_roscomm_tests/CMakeLists.txt
+++ b/tests/rtt_roscomm_tests/CMakeLists.txt
@@ -1,11 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rtt_roscomm_tests)
 
-find_package(OROCOS-RTT REQUIRED COMPONENTS rtt-scripting)
-include(${OROCOS-RTT_USE_FILE_PATH}/UseOROCOS-RTT.cmake)
-
 find_package(catkin REQUIRED
-  COMPONENTS rtt_roscomm rtt_std_msgs rostest)
+  COMPONENTS rtt_ros rtt_roscomm rtt_std_msgs rostest)
 
 catkin_package()
 

--- a/tests/rtt_rospack_tests/CMakeLists.txt
+++ b/tests/rtt_rospack_tests/CMakeLists.txt
@@ -1,11 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rtt_rospack_tests)
 
-find_package(OROCOS-RTT REQUIRED COMPONENTS rtt-scripting)
-include(${OROCOS-RTT_USE_FILE_PATH}/UseOROCOS-RTT.cmake)
-
 find_package(catkin REQUIRED
-  COMPONENTS rtt_rospack roslib)
+  COMPONENTS rtt_ros rtt_rospack roslib)
 
 catkin_package()
 


### PR DESCRIPTION
This is to reduce user-error after the application of https://github.com/orocos-toolchain/rtt/pull/6
