### PR TITLE
rtt_roscomm: Export include directories explicitly in GenerateRTTROSCommPackage.cmake.em

### DIFF
--- a/rtt_roscomm/cmake/GenerateRTTROSCommPackage.cmake.em
+++ b/rtt_roscomm/cmake/GenerateRTTROSCommPackage.cmake.em
@@ -88,6 +88,7 @@ macro(ros_generate_rtt_typekit package)
     rosbuild_find_ros_package(${package})
     if(DEFINED ${package}_PACKAGE_PATH)
       set(${package}_FOUND TRUE)
+      set(${package}_INCLUDE_DIRS "${${package}_PACKAGE_PATH}/include")
       file(GLOB MSG_FILES "${${package}_PACKAGE_PATH}/msg/*.msg")
       set(${package}_EXPORTED_TARGETS)
     endif()
@@ -215,8 +216,9 @@ macro(ros_generate_rtt_typekit package)
     endif()
 
     # Add the typekit libraries to the dependecies exported by this project
-    LIST(APPEND ${${PROJECT_NAME}_EXPORTED_TARGETS} "rtt-${package}-typekit")
-    LIST(APPEND ${${PROJECT_NAME}_EXPORTED_TARGETS} "rtt-${package}-ros-transport")
+#    LIST(APPEND ${PROJECT_NAME}_EXPORTED_TARGETS "rtt-${package}-typekit")        # <-- This is already done in orocos_typekit().
+#    LIST(APPEND ${PROJECT_NAME}_EXPORTED_TARGETS "rtt-${package}-ros-transport")  # <-- This is already done in orocos_typekit().
+    LIST(APPEND ${PROJECT_NAME}_EXPORTED_INCLUDE_DIRS "${rtt_roscomm_GENERATED_HEADERS_OUTPUT_DIRECTORY}/orocos" ${${package}_INCLUDE_DIRS})
 
     add_file_dependencies(  ${_template_types_dst_dir}/ros_${package}_typekit.cpp "${CMAKE_CURRENT_LIST_FILE}" ${ROSMSGS_GENERATED_BOOST_HEADERS} )
     add_file_dependencies(  ${_template_types_dst_dir}/ros_${package}_transport.cpp "${CMAKE_CURRENT_LIST_FILE}" ${ROSMSGS_GENERATED_BOOST_HEADERS} )
@@ -290,6 +292,7 @@ macro(ros_generate_rtt_service_proxies package)
     rosbuild_find_ros_package(${package})
     if(DEFINED ${package}_PACKAGE_PATH)
       set(${package}_FOUND TRUE)
+      set(${package}_INCLUDE_DIRS "${${package}_PACKAGE_PATH}/include")
       file(GLOB SRV_FILES "${${package}_PACKAGE_PATH}/srv/*.srv")
       set(${package}_EXPORTED_TARGETS)
     endif()


### PR DESCRIPTION
This pull request requires https://github.com/orocos-toolchain/rtt/commit/60a206070f5f404be349232008904ba2be9d4054.

All required headers for using the typekit will be made available to dependent packages within the same workspace if they call `use_orocos_package()` without involving catkin. Otherwise it would be required to list typekit packages twice:

```
# This will make the foo_msgs headers available as foo_msgs is a dependency of rtt_foo_msgs
find_package(catkin REQUIRED COMPONENTS rtt_foo_msgs)
include_directories(${catkin_INCLUDE_DIRS})
```

```
# This will make the generated rtt_foo_msgs headers and typekit libraries available
orocos_use_package(rtt_foo_msgs)
```

With this patch, only the second block is required, while the first can be left out if they are no other catkin packages you want to depend on.

There was also a bug in `GenerateRTTROSCommPackage.cmake.em` as

```
LIST(APPEND ${${PROJECT_NAME}_EXPORTED_TARGETS} "rtt-${package}-typekit")
```

should have been

```
LIST(APPEND ${PROJECT_NAME}_EXPORTED_TARGETS "rtt-${package}-typekit")
```
