### PR TITLE
Added rtt_rosbuild_tests package

### DIFF
--- a/tests/rtt_rosbuild_tests/CMakeLists.txt
+++ b/tests/rtt_rosbuild_tests/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 2.4.6)
+include($ENV{ROS_ROOT}/core/rosbuild/rosbuild.cmake)
+
+# Set the build type.  Options are:
+#  Coverage       : w/ debug symbols, w/o optimization, w/ code-coverage
+#  Debug          : w/ debug symbols, w/o optimization
+#  Release        : w/o debug symbols, w/ optimization
+#  RelWithDebInfo : w/ debug symbols, w/ optimization
+#  MinSizeRel     : w/o debug symbols, w/ optimization, stripped binaries
+#set(ROS_BUILD_TYPE RelWithDebInfo)
+
+rosbuild_init()
+
+#set the default path for built executables to the "bin" directory
+set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin)
+#set the default path for built libraries to the "lib" directory
+set(LIBRARY_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/lib)
+
+#uncomment if you have defined messages
+rosbuild_genmsg()
+#uncomment if you have defined services
+#rosbuild_gensrv()
+
+#common commands for building c++ executables and libraries
+#rosbuild_add_library(${PROJECT_NAME} src/example.cpp)
+#target_link_libraries(${PROJECT_NAME} another_library)
+#rosbuild_add_boost_directories()
+#rosbuild_link_boost(${PROJECT_NAME} thread)
+#rosbuild_add_executable(example examples/example.cpp)
+#target_link_libraries(example ${PROJECT_NAME})
+
+add_subdirectory(typekit)
+
+find_package(rtt_ros REQUIRED)
+include_directories(include/orocos)
+
+orocos_component(rtt_rosbuild_component src/component.cpp)
+target_link_libraries(rtt_rosbuild_component rtt-${PROJECT_NAME}-typekit)
+
+orocos_generate_package()

--- a/tests/rtt_rosbuild_tests/Makefile
+++ b/tests/rtt_rosbuild_tests/Makefile
@@ -1,0 +1,1 @@
+include $(shell rospack find mk)/cmake.mk

--- a/tests/rtt_rosbuild_tests/manifest.xml
+++ b/tests/rtt_rosbuild_tests/manifest.xml
@@ -1,0 +1,22 @@
+<package>
+  <description brief="rtt_ros_rosbuild_test">
+
+     rtt_ros_rosbuild_test
+
+  </description>
+  <author>Johannes Meyer</author>
+  <license>BSD</license>
+  <review status="unreviewed" notes=""/>
+  <url>http://ros.org/wiki/rtt_ros_rosbuild_test</url>
+
+  <depend package="rtt_ros" />
+  <depend package="rtt_roscomm" />
+
+  <export>
+    <rtt_ros>
+      <plugin_depend>rtt_roscomm</plugin_depend>
+    </rtt_ros>
+  </export>
+</package>
+
+

--- a/tests/rtt_rosbuild_tests/msg/String.msg
+++ b/tests/rtt_rosbuild_tests/msg/String.msg
@@ -1,0 +1,1 @@
+string data

--- a/tests/rtt_rosbuild_tests/scripts/test_rtt_ros_rosbuild
+++ b/tests/rtt_rosbuild_tests/scripts/test_rtt_ros_rosbuild
@@ -1,0 +1,3 @@
+#!/bin/sh
+export ORO_LOGLEVEL=5
+exec rosrun rtt_ros deployer -s $(rospack find rtt_rosbuild_tests)/scripts/test_rtt_ros_rosbuild.ops

--- a/tests/rtt_rosbuild_tests/scripts/test_rtt_ros_rosbuild.ops
+++ b/tests/rtt_rosbuild_tests/scripts/test_rtt_ros_rosbuild.ops
@@ -1,0 +1,8 @@
+import("rtt_ros")
+ros.import("rtt_rosbuild_tests")
+
+loadComponent("test", "rtt_rosbuild_tests::Component")
+stream("test.string", rostopic.connection("chatter"))
+test.setPeriod(1.0)
+
+test.start()

--- a/tests/rtt_rosbuild_tests/src/component.cpp
+++ b/tests/rtt_rosbuild_tests/src/component.cpp
@@ -1,0 +1,30 @@
+#include <rtt/RTT.hpp>
+#include <rtt/Component.hpp>
+
+#include <rtt_rosbuild_tests/typekit/String.h>
+
+namespace rtt_rosbuild_tests {
+
+class Component : public RTT::TaskContext
+{
+public:
+    Component(const std::string& name)
+        : RTT::TaskContext(name)
+    {
+        this->addPort("string", port_string);
+    }
+
+    void updateHook()
+    {
+        rtt_rosbuild_tests::String string;
+        string.data = "Hello from " ROS_PACKAGE_NAME "!";
+        port_string.write(string);
+    }
+
+private:
+    RTT::OutputPort<rtt_rosbuild_tests::String> port_string;
+};
+
+} // namespace rtt_rosbuild_tests
+
+ORO_CREATE_COMPONENT(rtt_rosbuild_tests::Component)

--- a/tests/rtt_rosbuild_tests/typekit/CMakeLists.txt
+++ b/tests/rtt_rosbuild_tests/typekit/CMakeLists.txt
@@ -1,0 +1,6 @@
+find_package(rtt_roscomm REQUIRED)
+
+ros_generate_rtt_typekit(rtt_rosbuild_tests)
+ros_generate_rtt_service_proxies(rtt_rosbuild_tests)
+
+orocos_generate_package(rtt_rosbuild_tests_msgs-${OROCOS_TARGET})


### PR DESCRIPTION
This package does not run automatic tests yet, as it will not be recognized by catkin.

In order to test rtt_ros_integration with rosbuild, run

```
rosmake rtt_rosbuild_tests && rosrun rtt_rosbuild_tests test test_rtt_ros_rosbuild
```

This will start an deployer running a test component that streams `rtt_rosbuild_tests/String` messages on topic `chatter`.
