### PR TITLE
Fixed recursive import of ROS packages

### DIFF
--- a/rtt_ros/src/rtt_ros_service.cpp
+++ b/rtt_ros/src/rtt_ros_service.cpp
@@ -197,6 +197,7 @@ public:
         // Check if it's already been imported
         if(*it == "rtt_ros" || loader->isImported(*it)) {
           RTT::log(RTT::Debug) << "Package dependency '"<< *it <<"' already imported." << RTT::endlog();
+          found_packages = true;
           continue;
         }
 


### PR DESCRIPTION
Without this patch the `ros.import("foo")` operation returned an error if package foo has already been loaded. Even if the same package is not imported twice explicitly, it might happen that another package that depends on foo has already been imported.

Example:

```
Deployer [S]> import("rtt_ros")
 = true                

Deployer [S]> ros.import("rtt_sensor_msgs")
 = true                

Deployer [S]> ros.import("rtt_geometry_msgs")
23.826 [ Warning][ROSService::import("rtt_geometry_msgs")] Could not load any plugins from ROS package "rtt_geometry_msgs" or it's dependencies.
 = false               
```
