### PR TITLE
rtt_rosparam: Added support for subservices

### DIFF
--- a/rtt_rosparam/src/rtt_rosparam_service.cpp
+++ b/rtt_rosparam/src/rtt_rosparam_service.cpp
@@ -29,62 +29,62 @@ public:
     this->addConstant("COMPONENT",COMPONENT);
 
     this->addOperation("getAllRelative", &ROSParamService::getParamsRelative, this)
-      .doc("Gets all properties of this component from the ROS param server in the relative namespace.");
+      .doc("Gets all properties of this component and its services from the ROS param server in the relative namespace.");
     this->addOperation("getAllAbsolute", &ROSParamService::getParamsAbsolute, this)
-      .doc("Gets all properties of this component from the ROS param server in the absolute namespace.");
+      .doc("Gets all properties of this component and its services from the ROS param server in the absolute namespace.");
     this->addOperation("getAllPrivate", &ROSParamService::getParamsPrivate, this)
-      .doc("Gets all properties of this component from the ROS param server in the node's private namespace.");
+      .doc("Gets all properties of this component and its services from the ROS param server in the node's private namespace.");
     this->addOperation("getAllComponentPrivate", &ROSParamService::getParamsComponentPrivate, this)
-      .doc("Gets all properties of this component from the ROS param server in the component's private namespace.");
+      .doc("Gets all properties of this component and its services from the ROS param server in the component's private namespace.");
     this->addOperation("getAll", &ROSParamService::getParamsComponentPrivate, this)
-      .doc("Gets all properties of this component from the ROS param server in the component's private namespace. This is just an alias for getAllComponentPrivate().");
+      .doc("Gets all properties of this component and its services from the ROS param server in the component's private namespace. This is just an alias for getAllComponentPrivate().");
 
     this->addOperation("setAllRelative", &ROSParamService::setParamsRelative, this)
-      .doc("Sets all properties of this component on the ROS param server from the similarly-named property of this component in the relative namespace.");
+      .doc("Sets all properties of this component on the ROS param server from the similarly-named property or service of this component in the relative namespace.");
     this->addOperation("setAllAbsolute", &ROSParamService::setParamsAbsolute, this)
-      .doc("Sets all properties of this component on the ROS param server from the similarly-named property of this component in the absolute namespace.");
+      .doc("Sets all properties of this component on the ROS param server from the similarly-named property or service of this component in the absolute namespace.");
     this->addOperation("setAllPrivate", &ROSParamService::setParamsPrivate, this)
-      .doc("Sets all properties of this component on the ROS param server from the similarly-named property of this component in the node's private namespace.");
+      .doc("Sets all properties of this component on the ROS param server from the similarly-named property or service of this component in the node's private namespace.");
     this->addOperation("setAllComponentPrivate", &ROSParamService::setParamsComponentPrivate, this)
-      .doc("Sets all properties of this component on the ROS param server from the similarly-named property of this component in the component's private namespace.");
+      .doc("Sets all properties of this component on the ROS param server from the similarly-named property or service of this component in the component's private namespace.");
     this->addOperation("setAll", &ROSParamService::setParamsComponentPrivate, this)
-      .doc("Sets all properties of this component on the ROS param server from the similarly-named property of this component in the component's private namespace. This is just an alias for setAll().");
+      .doc("Sets all properties of this component on the ROS param server from the similarly-named property or service of this component in the component's private namespace. This is just an alias for setAll().");
 
     this->addOperation("get", &ROSParamService::getParam, this) 
-      .doc("Gets one property of this component from the ROS param server based on the given resolution policy.")
+      .doc("Gets one property of this component from the ROS param server based on the given resolution policy or configures a service.")
       .arg("name", "Name of the property / parameter.")
       .arg("policy", "ROS parameter namespace resolution policy.");
 
     this->addOperation("getRelative", &ROSParamService::getParamRelative, this) 
-      .doc("Gets one property of this component from the ROS param server in the relative namespace.")
-      .arg("name", "Name of the property / parameter.");
+      .doc("Gets one property of this component from the ROS param server in the relative namespace or configures a service.")
+      .arg("name", "Name of the property / service / parameter.");
     this->addOperation("getAbsolute", &ROSParamService::getParamAbsolute, this) 
-      .doc("Gets one property of this component from the ROS param server in the absolute namespace.")
-      .arg("name", "Name of the property / parameter.");
+      .doc("Gets one property of this component from the ROS param server in the absolute namespace or configures a service.")
+      .arg("name", "Name of the property / service / parameter.");
     this->addOperation("getPrivate", &ROSParamService::getParamPrivate, this) 
-      .doc("Gets one property of this component from the ROS param server in the node's private namespace.")
-      .arg("name", "Name of the property / parameter.");
+      .doc("Gets one property of this component from the ROS param server in the node's private namespace or configures a service.")
+      .arg("name", "Name of the property / service / parameter.");
     this->addOperation("getComponentPrivate", &ROSParamService::getParamComponentPrivate, this) 
-      .doc("Gets one property of this component from the ROS param server in the component's private namespace.")
-      .arg("name", "Name of the property / parameter.");
+      .doc("Gets one property of this component from the ROS param server in the component's private namespace or configures a service.")
+      .arg("name", "Name of the property / service / parameter.");
 
     this->addOperation("set", &ROSParamService::setParam, this) 
-      .doc("Sets one parameter on the ROS param server from the similarly-named property of this component based on the given resolution policy.")
-      .arg("name", "Name of the property / parameter.")
+      .doc("Sets one parameter on the ROS param server from the similarly-named property or service of this component based on the given resolution policy.")
+      .arg("name", "Name of the property / service / parameter.")
       .arg("policy", "ROS parameter namespace resolution policy.");
 
     this->addOperation("setRelative", &ROSParamService::setParamRelative, this) 
-      .doc("Sets one parameter on the ROS param server from the similarly-named property of this component in the relative namespace.")
-      .arg("name", "Name of the property / parameter.");
+      .doc("Sets one parameter on the ROS param server from the similarly-named property or service of this component in the relative namespace.")
+      .arg("name", "Name of the property / service / parameter.");
     this->addOperation("setAbsolute", &ROSParamService::setParamAbsolute, this) 
-      .doc("Sets one parameter on the ROS param server from the similarly-named property of this component in the absolute namespace.")
-      .arg("name", "Name of the property / parameter.");
+      .doc("Sets one parameter on the ROS param server from the similarly-named property or service of this component in the absolute namespace.")
+      .arg("name", "Name of the property / service / parameter.");
     this->addOperation("setPrivate", &ROSParamService::setParamPrivate, this) 
-      .doc("Sets one parameter on the ROS param server from the similarly-named property of this component in the node's private namespace.")
-      .arg("name", "Name of the property / parameter.");
+      .doc("Sets one parameter on the ROS param server from the similarly-named property or service of this component in the node's private namespace.")
+      .arg("name", "Name of the property / service / parameter.");
     this->addOperation("setComponentPrivate", &ROSParamService::setParamComponentPrivate, this) 
-      .doc("Sets one parameter on the ROS param server from the similarly-named property of this component in the component's private namespace.")
-      .arg("name", "Name of the property / parameter.");
+      .doc("Sets one parameter on the ROS param server from the similarly-named property or service of this component in the component's private namespace.")
+      .arg("name", "Name of the property / service / parameter.");
   
   }
 private:


### PR DESCRIPTION
This patch will add sub-service support to rtt_rosparam. A component could have nested services that also have properties. Currently it is not possible to load or store parameters of nested services.

There are several modifications, that I shortly summarize here:
1. I added policy-specific operations `getAllXXX()` and `setAllXXX()` in analogy to the per-parameter operations. This is not directly related to services, but I need it to fetch all parameters of a component with a nested service from another namespace than it's private component namespace (dd2ef57).
2. The `getAllXXX()` and `setAllXXX()` operations will recurse into services and also get/set their properties from/on the parameter server. This will only work for services, not for peers.
3. If a service is passed to `getXXX(name)` or `setXXX(name)` operations and no property of that name exists, the rosparam service will search a service with that name and recursively call `getAllXXX()`/`setAllXXX()` for that specific service only.

Note that `getAllAbsolute()` and `setAllAbsolute()` (where the latter probably does not make so much sense anyway) currently are broken due to https://github.com/ros/ros_comm/pull/313.

Documentation in [README.md](https://github.com/jhu-lcsr-forks/rtt_ros_integration/blob/hydro-devel/README.md) still needs to be updated...
