### PR TITLE
Cleaned up package dependencies

### DIFF
--- a/rtt_actionlib/package.xml
+++ b/rtt_actionlib/package.xml
@@ -13,8 +13,6 @@
   
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>ocl</build_depend>
-  <build_depend>rtt</build_depend>
   <build_depend>rtt_ros</build_depend>
   <build_depend>rtt_roscomm</build_depend>
   <build_depend>roscpp</build_depend>
@@ -22,8 +20,6 @@
   <build_depend>actionlib_msgs</build_depend>
   <build_depend>rtt_actionlib_msgs</build_depend>
 
-  <run_depend>ocl</run_depend>
-  <run_depend>rtt</run_depend>
   <run_depend>rtt_ros</run_depend>
   <run_depend>rtt_roscomm</run_depend>
   <run_depend>roscpp</run_depend>

--- a/rtt_ros/CMakeLists.txt
+++ b/rtt_ros/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rtt_ros)
 
-find_package(catkin REQUIRED COMPONENTS roscpp rospack)
+find_package(catkin REQUIRED COMPONENTS rospack rostime)
 
 find_package(OROCOS-RTT REQUIRED 
   COMPONENTS rtt-marshalling rtt-scripting)
@@ -9,7 +9,7 @@ include(${OROCOS-RTT_USE_FILE_PATH}/UseOROCOS-RTT.cmake)
 
 catkin_package(
   INCLUDE_DIRS include
-  CATKIN_DEPENDS roscpp
+  CATKIN_DEPENDS rostime
   CFG_EXTRAS rtt_ros-extras.cmake)
 
 set(CMAKE_BUILD_TYPE RelWithDebInfo)

--- a/rtt_ros/include/rtt_ros/time.h
+++ b/rtt_ros/include/rtt_ros/time.h
@@ -1,8 +1,8 @@
 #ifndef __RTT_ROS_TIME_H
 #define __RTT_ROS_TIME_H
 
-#include <rtt/RTT.hpp>
-#include <ros/ros.h>
+#include <rtt/os/TimeService.hpp>
+#include <ros/time.h>
 
 namespace rtt_ros {
   namespace time {

--- a/rtt_ros/package.xml
+++ b/rtt_ros/package.xml
@@ -17,19 +17,19 @@
 
   <build_depend>rtt</build_depend>
   <build_depend>ocl</build_depend>
-  <build_depend>roscpp</build_depend>
+  <build_depend>rostime</build_depend>
   <build_depend>rospack</build_depend>
   <build_depend>libxml2</build_depend>
 
   <run_depend>rtt</run_depend>
   <run_depend>ocl</run_depend>
-  <run_depend>roscpp</run_depend>
+  <run_depend>rostime</run_depend>
   <run_depend>rospack</run_depend>
   <run_depend>libxml2</run_depend>
 
-  <run_depend>rtt_rosnode</run_depend>
-  <run_depend>rtt_rospack</run_depend>
-  <run_depend>rtt_rosparam</run_depend>
+  <!--<run_depend>rtt_rosnode</run_depend>-->
+  <!--<run_depend>rtt_rospack</run_depend>-->
+  <!--<run_depend>rtt_rosparam</run_depend>-->
 
   <export>
     <rtt_ros>

--- a/rtt_ros/src/rtt_ros_service.cpp
+++ b/rtt_ros/src/rtt_ros_service.cpp
@@ -22,7 +22,6 @@
 #include <rtt/plugin/PluginLoader.hpp>
 #include <rtt/types/TypekitRepository.hpp>
 
-#include <ros/ros.h>
 #include <rospack/rospack.h>
 
 #include <rtt_ros/time.h>

--- a/rtt_roscomm/package.xml
+++ b/rtt_roscomm/package.xml
@@ -16,18 +16,17 @@
   
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>ocl</build_depend>
-  <build_depend>rtt</build_depend>
+  <build_depend>rtt_ros</build_depend>
   <build_depend>rtt_rospack</build_depend>
   <build_depend>rtt_rosnode</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>genmsg</build_depend>
 
-  <run_depend>ocl</run_depend>
-  <run_depend>rtt</run_depend>
+  <run_depend>rtt_ros</run_depend>
   <run_depend>rtt_rospack</run_depend>
   <run_depend>rtt_rosnode</run_depend>
   <run_depend>roscpp</run_depend>
+  <run_depend>genmsg</run_depend>
   
   <export>
     <rtt_ros>

--- a/rtt_rosnode/package.xml
+++ b/rtt_rosnode/package.xml
@@ -13,12 +13,10 @@
   
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>rtt</build_depend>
-  <build_depend>ocl</build_depend>
+  <build_depend>rtt_ros</build_depend>
   <build_depend>roscpp</build_depend>
 
-  <run_depend>rtt</run_depend>
-  <run_depend>ocl</run_depend>
+  <run_depend>rtt_ros</run_depend>
   <run_depend>roscpp</run_depend>
   
 </package>

--- a/rtt_rospack/package.xml
+++ b/rtt_rospack/package.xml
@@ -13,9 +13,9 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>rtt_ros</build_depend> 
   <build_depend>roslib</build_depend> 
-  <build_depend>rtt</build_depend> 
 
+  <run_depend>rtt_ros</run_depend> 
   <run_depend>roslib</run_depend> 
-  <run_depend>rtt</run_depend> 
 </package>

--- a/rtt_rosparam/CMakeLists.txt
+++ b/rtt_rosparam/CMakeLists.txt
@@ -17,7 +17,7 @@ include_directories(
 # build ROS param as a separate service
 orocos_service(rtt_rosparam src/rtt_rosparam_service.cpp)
 target_link_libraries(rtt_rosparam 
-  ${OROCOS-RTT_RTT-MARSHALLING_LIBRARY} 
+#  ${OROCOS-RTT_RTT-MARSHALLING_LIBRARY} 
   ${catkin_LIBRARIES})
 
 # Generate install targets and pkg-config files

--- a/rtt_rosparam/package.xml
+++ b/rtt_rosparam/package.xml
@@ -14,16 +14,12 @@
   
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>rtt</build_depend>
-  <build_depend>rtt_rospack</build_depend>
+  <build_depend>rtt_ros</build_depend>
   <build_depend>roscpp</build_depend>
-  <build_depend>ocl</build_depend>
 
-  <run_depend>rtt</run_depend>
-  <run_depend>rtt_rospack</run_depend>
+  <run_depend>rtt_ros</run_depend>
   <run_depend>roscpp</run_depend>
-  <run_depend>ocl</run_depend>
-
+  
   <export>
     <rtt_ros>
       <plugin_depend>rtt_rosnode</plugin_depend>


### PR DESCRIPTION
Objective:
- `rtt_ros` depends on `rtt`, `ocl`, `rospack` and `rostime` only.
- All other packages in rtt_ros_integration depend on `rtt_ros`. Direct dependencies to `rtt` and `ocl` have been removed.
- Only `rtt_roscomm`, `rtt_rosnode`, `rtt_rosparam` and `rtt_actionlib` depend on roscpp.
- Generated typekit packages depend on `rtt_roscomm`.

Other minor updates:
- `rtt_ros` should only use `rostime` headers, not `#include <ros/ros.h>` which is `roscpp`.
- `rtt_rosparam` does not need to be linked with rtt-marshalling.
