### PR TITLE
Fixed typekit linking with rtt_roscomm libraries when building with catkin

### DIFF
--- a/rtt_roscomm/cmake/GenerateRTTROSCommPackage.cmake.em
+++ b/rtt_roscomm/cmake/GenerateRTTROSCommPackage.cmake.em
@@ -203,8 +203,8 @@ macro(ros_generate_rtt_typekit package)
     # Targets
     orocos_typekit(         rtt-${package}-typekit ${_template_types_dst_dir}/ros_${package}_typekit.cpp ${ROSMSG_TYPEKIT_PLUGINS})
     orocos_typekit(         rtt-${package}-ros-transport ${_template_types_dst_dir}/ros_${package}_transport.cpp )
-    target_link_libraries(  rtt-${package}-typekit ${catkin_LIBRARIES})
-    target_link_libraries(  rtt-${package}-ros-transport ${catkin_LIBRARIES})
+    target_link_libraries(  rtt-${package}-typekit ${catkin_LIBRARIES} ${USE_OROCOS_LIBRARIES})
+    target_link_libraries(  rtt-${package}-ros-transport ${catkin_LIBRARIES} ${USE_OROCOS_LIBRARIES})
 
     # Add an explicit dependency between the typekits and message files
     # TODO: Add deps for all msg dependencies
@@ -335,7 +335,7 @@ macro(ros_generate_rtt_service_proxies package)
 
     # Targets
     orocos_service(         rtt_${ROSPACKAGE}_ros_service_proxies ${_template_proxies_dst_dir}/rtt_ros_service_proxies.cpp)
-    target_link_libraries(  rtt_${ROSPACKAGE}_ros_service_proxies ${catkin_LIBRARIES})
+    target_link_libraries(  rtt_${ROSPACKAGE}_ros_service_proxies ${catkin_LIBRARIES} ${USE_OROCOS_LIBRARIES})
     if(DEFINED ${package}_EXPORTED_TARGETS)
       add_dependencies(       rtt_${ROSPACKAGE}_ros_service_proxies ${${package}_EXPORTED_TARGETS})
     endif()

--- a/rtt_roscomm/src/rtt_rosservice_registry_service.cpp
+++ b/rtt_roscomm/src/rtt_rosservice_registry_service.cpp
@@ -60,7 +60,7 @@ public:
       return factories_[service_type].get();
     }
 
-    RTT::log(RTT::Error)<<"Service type \""<<service_type<<"\" has not been registerd with the rosserivce_registry service."<<RTT::endlog();
+    RTT::log(RTT::Error)<<"Service type \""<<service_type<<"\" has not been registered with the rosservice_registry service."<<RTT::endlog();
 
     return NULL;
   }


### PR DESCRIPTION
As auto linking has been disabled in catkin builds, typekit libraries have not been linked anymore to the rtt_rostopic library. Although this usually is not a problem as the `rtt_roscomm` package is loaded before any typekit package if you use `ros.import("rtt_foo_msgs")`, this patch allows to also load typekit packages directly with plain `import("rtt_foo_msgs")` operation calls if you do not want to stream ports but only use them internally. Previously that import call failed with an error due to the unresolved symbol `ros_integration::RosPublishActivity::ros_pub_act`.

Direct (non-recursive) import of typekit packages currently also fails for typekits that contain a service proxy plugin, as the global `rosservice_registry` service is not yet loaded. But this should be easy to fix (another PR will follow)...
