### PR TITLE
Added a CATKIN_IGNORE marker in the template and remove it in create_rtt_pkg

### DIFF
--- a/rtt_roscomm/scripts/create_rtt_pkg
+++ b/rtt_roscomm/scripts/create_rtt_pkg
@@ -80,5 +80,6 @@ for i in $files; do
   tgtname=$(echo $(basename "$i") | sed -e "s/pkgname/$pkgname/g;s/Pkgname/$cappkgname/g;")
   cat "$i" | sed -e "s/@PKGNAME@/$allcappkgname/g;s/@pkgname@/$pkgname/g;s/@Pkgname@/$cappkgname/g;s|@deplist@|$deplist|g;s|@rtt_deplist@|$rtt_deplist|g;s|@catkin_deplist@|$catkin_deplist|g" > rtt_$pkgname/$tgtname
 done
+rm -vf rtt_$pkgname/CATKIN_IGNORE
 
 echo "Successfully created rtt_$pkgname."


### PR DESCRIPTION
The patch makes sure that catkin does not find the `package.xml` in the `rtt_roscomm_pkg_template` folder for any reason, neither in the package source nor in devel-space nor in install-space.

This is required if the devel-space is located within the source folder, which in general is possible. Otherwise the template is found as package (with a broken `package.xml`) when cmake is executed the 2nd time after the template has been copied to devel-space.
