### PR TITLE
rtt_roscomm: Unified naming scheme for rtt_rosservice and use a singleton for the ROSServiceRegistryService

### DIFF
--- a/rtt_roscomm/CMakeLists.txt
+++ b/rtt_roscomm/CMakeLists.txt
@@ -41,7 +41,7 @@ orocos_service(rtt_rosservice_registry
 
 orocos_service(rtt_rosservice
   src/rtt_rosservice_service.cpp)
-target_link_libraries(rtt_rosservice ${catkin_LIBRARIES})
+target_link_libraries(rtt_rosservice rtt_rosservice_registry ${catkin_LIBRARIES})
 
 # Generate install targets and pkg-config files
 orocos_generate_package()

--- a/rtt_roscomm/cmake/GenerateRTTROSCommPackage.cmake.em
+++ b/rtt_roscomm/cmake/GenerateRTTROSCommPackage.cmake.em
@@ -315,7 +315,7 @@ macro(ros_generate_rtt_service_proxies package)
       set(ROS_SRV_TYPE "${ROSPACKAGE}::${ROS_SRV_NAME}")
       set(ROS_SRV_TYPENAME "${ROSPACKAGE}/${ROS_SRV_NAME}")
 
-      # rtt_ros_service_proxies.cpp.in
+      # rtt_rosservice_proxies.cpp.in
       set(ROS_SRV_HEADERS "${ROS_SRV_HEADERS}#include <${ROS_SRV_TYPENAME}.h>\n")
       set(ROS_SRV_FACTORIES "${ROS_SRV_PROXY_FACTORIES}  success = success && register_service_factory(new ROSServiceProxyFactory<${ROS_SRV_TYPE}>(\"${ROS_SRV_TYPENAME}\"));\n")
 
@@ -323,10 +323,10 @@ macro(ros_generate_rtt_service_proxies package)
     
     # Service proxy factories
     configure_file( 
-      ${_template_proxies_src_dir}/rtt_ros_service_proxies.cpp.in 
-      ${_template_proxies_dst_dir}/rtt_ros_service_proxies.cpp @@ONLY )
+      ${_template_proxies_src_dir}/rtt_rosservice_proxies.cpp.in
+      ${_template_proxies_dst_dir}/rtt_rosservice_proxies.cpp @@ONLY )
 
-    add_file_dependencies( ${_template_proxies_dst_dir}/rtt_ros_service_proxies.cpp ${SRV_FILES})
+    add_file_dependencies( ${_template_proxies_dst_dir}/rtt_rosservice_proxies.cpp ${SRV_FILES})
     
     include_directories(
       ${CATKIN_DEVEL_PREFIX}/include 
@@ -334,15 +334,15 @@ macro(ros_generate_rtt_service_proxies package)
       ${catkin_INCLUDE_DIRS})
 
     # Targets
-    orocos_service(         rtt_${ROSPACKAGE}_ros_service_proxies ${_template_proxies_dst_dir}/rtt_ros_service_proxies.cpp)
-    target_link_libraries(  rtt_${ROSPACKAGE}_ros_service_proxies ${catkin_LIBRARIES} ${USE_OROCOS_LIBRARIES})
+    orocos_service(         rtt_${ROSPACKAGE}_rosservice_proxies ${_template_proxies_dst_dir}/rtt_rosservice_proxies.cpp)
+    target_link_libraries(  rtt_${ROSPACKAGE}_rosservice_proxies ${catkin_LIBRARIES} ${USE_OROCOS_LIBRARIES})
     if(DEFINED ${package}_EXPORTED_TARGETS)
-      add_dependencies(       rtt_${ROSPACKAGE}_ros_service_proxies ${${package}_EXPORTED_TARGETS})
+      add_dependencies(       rtt_${ROSPACKAGE}_rosservice_proxies ${${package}_EXPORTED_TARGETS})
     endif()
-    add_file_dependencies(  ${_template_proxies_dst_dir}/rtt_ros_service_proxies.cpp "${CMAKE_CURRENT_LIST_FILE}")
+    add_file_dependencies(  ${_template_proxies_dst_dir}/rtt_rosservice_proxies.cpp "${CMAKE_CURRENT_LIST_FILE}")
 
     get_directory_property(_additional_make_clean_files ADDITIONAL_MAKE_CLEAN_FILES)
-    list(APPEND _additional_make_clean_files "${_template_proxies_dst_dir}/rtt_ros_service_proxies.cpp")
+    list(APPEND _additional_make_clean_files "${_template_proxies_dst_dir}/rtt_rosservice_proxies.cpp")
     set_directory_properties(PROPERTIES 
       ADDITIONAL_MAKE_CLEAN_FILES "${_additional_make_clean_files}")
 

--- a/rtt_roscomm/include/rtt_rosservice/rtt_rosservice_proxy.h
+++ b/rtt_roscomm/include/rtt_rosservice/rtt_rosservice_proxy.h
@@ -1,14 +1,10 @@
-#ifndef __RTT_ROSSERVICE_ROS_SERVICE_PROXY_H
-#define __RTT_ROSSERVICE_ROS_SERVICE_PROXY_H
-
-#include <boost/range/iterator_range.hpp>
-#include <boost/algorithm/string.hpp>
+#ifndef __RTT_ROSSERVICE_RTT_ROSSERVICE_PROXY_H
+#define __RTT_ROSSERVICE_RTT_ROSSERVICE_PROXY_H
 
 #include <ros/ros.h>
 
 #include <rtt/RTT.hpp>
 #include <rtt/plugin/ServicePlugin.hpp>
-#include <rtt/internal/GlobalService.hpp>
 
 //! Abstract ROS Service Proxy
 class ROSServiceProxyBase
@@ -177,4 +173,4 @@ public:
   }
 };
 
-#endif // ifndef __RTT_ROSSERVICE_ROS_SERVICE_PROXY_H
+#endif // ifndef __RTT_ROSSERVICE_RTT_ROSSERVICE_PROXY_H

--- a/rtt_roscomm/include/rtt_rosservice/rtt_rosservice_registry_service.h
+++ b/rtt_roscomm/include/rtt_rosservice/rtt_rosservice_registry_service.h
@@ -1,0 +1,43 @@
+#ifndef __RTT_ROSSERVICE_RTT_ROSSERVICE_REGISTRY_SERVICE_H
+#define __RTT_ROSSERVICE_RTT_ROSSERVICE_REGISTRY_SERVICE_H
+
+#include <rtt/RTT.hpp>
+#include <boost/shared_ptr.hpp>
+
+class ROSServiceRegistryService;
+class ROSServiceProxyFactoryBase;
+typedef boost::shared_ptr<ROSServiceRegistryService> ROSServiceRegistryServicePtr;
+
+class ROSServiceRegistryService : public RTT::Service
+{
+public:
+  static ROSServiceRegistryServicePtr Instance();
+  static void Release();
+
+  /** \brief Register a ROS service proxy factory
+   *
+   * This enables the ROSServiceRegistryService to construct ROS service clients and
+   * servers from a string name.
+   */
+  bool registerServiceFactory(ROSServiceProxyFactoryBase* factory);
+
+  bool hasServiceFactory(const std::string &service_type);
+
+  ROSServiceProxyFactoryBase* getServiceFactory(const std::string &service_type);
+
+private:
+  /**
+   * Instantiates this service.
+   * @param owner The owner or null in case of global.
+   */
+  ROSServiceRegistryService(RTT::TaskContext* owner);
+
+  //! ROS service proxy factories
+  static std::map<std::string, boost::shared_ptr<ROSServiceProxyFactoryBase> > factories_;
+  static RTT::os::MutexRecursive factory_lock_;
+
+  //! The singleton instance
+  static ROSServiceRegistryServicePtr s_instance_;
+};
+
+#endif // __RTT_ROSSERVICE_RTT_ROSSERVICE_REGISTRY_SERVICE_H

--- a/rtt_roscomm/rtt_roscomm_pkg_template/src/rtt_rosservice_proxies.cpp.in
+++ b/rtt_roscomm/rtt_roscomm_pkg_template/src/rtt_rosservice_proxies.cpp.in
@@ -3,7 +3,7 @@
 #include <rtt/plugin/ServicePlugin.hpp>
 #include <rtt/internal/GlobalService.hpp>
 
-#include <rtt_rosservice/ros_service_proxy.h> 
+#include <rtt_rosservice/rtt_rosservice_proxy.h>
 
 ////////////////////////////////////////////////////////////////////////////////
 @ROS_SRV_HEADERS@

--- a/rtt_roscomm/rtt_roscomm_pkg_template/src/rtt_rosservice_proxies.cpp.in
+++ b/rtt_roscomm/rtt_roscomm_pkg_template/src/rtt_rosservice_proxies.cpp.in
@@ -3,6 +3,7 @@
 #include <rtt/plugin/ServicePlugin.hpp>
 #include <rtt/internal/GlobalService.hpp>
 
+#include <rtt_rosservice/rtt_rosservice_registry_service.h>
 #include <rtt_rosservice/rtt_rosservice_proxy.h>
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -11,13 +12,14 @@
 
 bool registerROSServiceProxies() {
   // Get the ros service registry service
-  if(!RTT::internal::GlobalService::Instance()->hasService("rosservice_registry")) {
+  ROSServiceRegistryServicePtr rosservice_registry = ROSServiceRegistryService::Instance();
+  if(!rosservice_registry) {
     return false;
   }
 
   // Get the factory registration operation
   RTT::OperationCaller<bool(ROSServiceProxyFactoryBase*)> register_service_factory = 
-    RTT::internal::GlobalService::Instance()->getService("rosservice_registry")->getOperation("registerServiceFactory");
+    rosservice_registry->getOperation("registerServiceFactory");
 
   // Make sure the registration operation is ready
   if(!register_service_factory.ready()) {

--- a/rtt_roscomm/src/rtt_rosservice_registry_service.cpp
+++ b/rtt_roscomm/src/rtt_rosservice_registry_service.cpp
@@ -3,80 +3,84 @@
 #include <rtt/plugin/ServicePlugin.hpp>
 #include <rtt/internal/GlobalService.hpp>
 
+#include <rtt_rosservice/rtt_rosservice_registry_service.h>
 #include <rtt_rosservice/rtt_rosservice_proxy.h>
 
-class ROSServiceRegistryService : public RTT::Service 
+ROSServiceRegistryServicePtr ROSServiceRegistryService::s_instance_;
+
+ROSServiceRegistryServicePtr ROSServiceRegistryService::Instance()
 {
-public:
-  /**
-   * Instantiates this service.
-   * @param owner The owner or null in case of global.
-   */
-  ROSServiceRegistryService(RTT::TaskContext* owner) 
-    : Service("rosservice_registry", owner)
-  {
-    this->doc("Global RTT Service for registering ROS service types.");
-    this->addOperation("registerServiceFactory", &ROSServiceRegistryService::registerServiceFactory, this, RTT::ClientThread);
-    this->addOperation("hasServiceFactory", &ROSServiceRegistryService::hasServiceFactory, this, RTT::ClientThread);
-    this->addOperation("getServiceFactory", &ROSServiceRegistryService::getServiceFactory, this, RTT::ClientThread);
+  if (!s_instance_) {
+    s_instance_.reset(new ROSServiceRegistryService(0));
+    RTT::internal::GlobalService::Instance()->addService(s_instance_);
+  }
+  return s_instance_;
+}
+
+void ROSServiceRegistryService::Release()
+{
+  s_instance_.reset();
+}
+
+ROSServiceRegistryService::ROSServiceRegistryService(RTT::TaskContext* owner)
+  : Service("rosservice_registry", owner)
+{
+  this->doc("Global RTT Service for registering ROS service types.");
+  this->addOperation("registerServiceFactory", &ROSServiceRegistryService::registerServiceFactory, this, RTT::ClientThread);
+  this->addOperation("hasServiceFactory", &ROSServiceRegistryService::hasServiceFactory, this, RTT::ClientThread);
+  this->addOperation("getServiceFactory", &ROSServiceRegistryService::getServiceFactory, this, RTT::ClientThread);
+}
+
+/** \brief Register a ROS service proxy factory
+ *
+ * This enables the ROSServiceRegistryService to construct ROS service clients and
+ * servers from a string name.
+ */
+bool ROSServiceRegistryService::registerServiceFactory(ROSServiceProxyFactoryBase* factory)
+{
+  RTT::os::MutexLock lock(factory_lock_);
+  if(factory == NULL) {
+    return false;
   }
 
-  /** \brief Register a ROS service proxy factory
-   *
-   * This enables the ROSServiceRegistryService to construct ROS service clients and
-   * servers from a string name.
-   */
-  bool registerServiceFactory(ROSServiceProxyFactoryBase* factory) 
-  {
-    RTT::os::MutexLock lock(factory_lock_);
-    if(factory == NULL) {
-      return false;
-    }
+  const std::string &ros_service_type = factory->getType();
 
-    const std::string &ros_service_type = factory->getType();
-
-    // Check if the factory type has yet to be registered
-    if(factories_.find(ros_service_type) == factories_.end()) {
-      // Store a new factory
-      factories_[ros_service_type] = boost::shared_ptr<ROSServiceProxyFactoryBase>(factory);
-    } else {
-      // Reset the existing factory
-      factories_[ros_service_type].reset(factory);
-    }
-
-    return true;
+  // Check if the factory type has yet to be registered
+  if(factories_.find(ros_service_type) == factories_.end()) {
+    // Store a new factory
+    factories_[ros_service_type] = boost::shared_ptr<ROSServiceProxyFactoryBase>(factory);
+  } else {
+    // Reset the existing factory
+    factories_[ros_service_type].reset(factory);
   }
 
-  bool hasServiceFactory(const std::string &service_type)
-  {
-    RTT::os::MutexLock lock(factory_lock_);
-    return factories_.find(service_type) != factories_.end();
+  return true;
+}
+
+bool ROSServiceRegistryService::hasServiceFactory(const std::string &service_type)
+{
+  RTT::os::MutexLock lock(factory_lock_);
+  return factories_.find(service_type) != factories_.end();
+}
+
+ROSServiceProxyFactoryBase* ROSServiceRegistryService::getServiceFactory(const std::string &service_type)
+{
+  RTT::os::MutexLock lock(factory_lock_);
+  if(factories_.find(service_type) != factories_.end()) {
+    return factories_[service_type].get();
   }
 
-  ROSServiceProxyFactoryBase* getServiceFactory(const std::string &service_type) 
-  {
-    RTT::os::MutexLock lock(factory_lock_);
-    if(factories_.find(service_type) != factories_.end()) {
-      return factories_[service_type].get();
-    }
+  RTT::log(RTT::Error)<<"Service type \""<<service_type<<"\" has not been registered with the rosservice_registry service."<<RTT::endlog();
 
-    RTT::log(RTT::Error)<<"Service type \""<<service_type<<"\" has not been registered with the rosservice_registry service."<<RTT::endlog();
-
-    return NULL;
-  }
-
-  //! ROS service proxy factories
-  static std::map<std::string, boost::shared_ptr<ROSServiceProxyFactoryBase> > factories_;
-  static RTT::os::MutexRecursive factory_lock_;
-};
+  return NULL;
+}
 
 std::map<std::string, boost::shared_ptr<ROSServiceProxyFactoryBase> > ROSServiceRegistryService::factories_;
 RTT::os::MutexRecursive ROSServiceRegistryService::factory_lock_;
 
 void loadROSServiceRegistryService()
 {
-  RTT::Service::shared_ptr rsrs(new ROSServiceRegistryService(NULL));
-  RTT::internal::GlobalService::Instance()->addService(rsrs);
+  ROSServiceRegistryService::Instance();
 }
 
 using namespace RTT;

--- a/rtt_roscomm/src/rtt_rosservice_registry_service.cpp
+++ b/rtt_roscomm/src/rtt_rosservice_registry_service.cpp
@@ -3,7 +3,7 @@
 #include <rtt/plugin/ServicePlugin.hpp>
 #include <rtt/internal/GlobalService.hpp>
 
-#include <rtt_rosservice/ros_service_proxy.h> 
+#include <rtt_rosservice/rtt_rosservice_proxy.h>
 
 class ROSServiceRegistryService : public RTT::Service 
 {

--- a/rtt_roscomm/src/rtt_rosservice_service.cpp
+++ b/rtt_roscomm/src/rtt_rosservice_service.cpp
@@ -2,8 +2,8 @@
 
 #include <rtt/RTT.hpp>
 #include <rtt/plugin/ServicePlugin.hpp>
-#include <rtt/internal/GlobalService.hpp>
 
+#include <rtt_rosservice/rtt_rosservice_registry_service.h>
 #include <rtt_rosservice/rtt_rosservice_proxy.h>
 
 using namespace RTT;
@@ -33,7 +33,7 @@ public:
       .arg( "service_type", "The ROS service type (like \"std_srvs/Empty\").");
 
     // Get the global ros service registry
-    rosservice_registry_ = RTT::internal::GlobalService::Instance()->getService("rosservice_registry");
+    rosservice_registry_ = ROSServiceRegistryService::Instance();
     has_service_factory = rosservice_registry_->getOperation("hasServiceFactory");
     get_service_factory = rosservice_registry_->getOperation("getServiceFactory");
   }

--- a/rtt_roscomm/src/rtt_rosservice_service.cpp
+++ b/rtt_roscomm/src/rtt_rosservice_service.cpp
@@ -1,9 +1,10 @@
+#include <boost/algorithm/string.hpp>
 
 #include <rtt/RTT.hpp>
 #include <rtt/plugin/ServicePlugin.hpp>
 #include <rtt/internal/GlobalService.hpp>
 
-#include <rtt_rosservice/ros_service_proxy.h> 
+#include <rtt_rosservice/rtt_rosservice_proxy.h>
 
 using namespace RTT;
 using namespace std;


### PR DESCRIPTION
The first commit just renames a few files that had `ros_service` in their name so that all files and libraries have the `rtt_rosservice_` prefix. This is just a cleanup to avoid confusion with the `rtt_ros_service` located in package `rtt_ros`.

The second commit adds a singleton pattern to the `ROSServiceRegistryService` class and updated all classes that use that service to call the static `ROSServiceRegistryService::Instance()` method instead of relying that the service has already been loaded in the global service. This fixes an error if typekit packages that contain service proxies are imported without using the `ros.import()` operation. They will now load the `rosservice_registry` service automatically.
